### PR TITLE
Fix for OSRAM light bulbs

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ function PhilipsHueAccessory(log, device, api) {
   this.device = device;
   this.api = api;
   this.log = log;
+  this.manufacturername = device.manufacturername;
 }
 
 // Get the ip address of the first available bridge with meethue.com or a network scan.
@@ -233,6 +234,9 @@ PhilipsHueAccessory.prototype = {
           state.on();
         }
         else {
+    	  if (this.manufacturername == "OSRAM") {
+            state.transitionInstant();
+          }
           state.off();
         }
         break;
@@ -346,7 +350,7 @@ PhilipsHueAccessory.prototype = {
 	var informationService = new Service.AccessoryInformation();
 
 	informationService
-		.setCharacteristic(Characteristic.Manufacturer, "Philips")
+		.setCharacteristic(Characteristic.Manufacturer, this.manufacturername)
 		.setCharacteristic(Characteristic.Model, this.model)
 		.setCharacteristic(Characteristic.SerialNumber, this.device.uniqueid)
 		.addCharacteristic(Characteristic.FirmwareRevision, this.device.swversion);


### PR DESCRIPTION
The OSRAM Lightify bulbs can not be turned off due to the transition time.
I made a few changes to actually represent the manufacture of the bulb instead of having "Philips" hardcoded. We can now check for "OSRAM" when turning off the bulb and call transitionInstant() in this case.