### PR TITLE
Added Philips hue bulb exclusion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Configuration sample:
           "platform": "PhilipsHue",
           "name": "Philips Hue",
           "ip_address": "127.0.0.1",
-          "username": "252deadbeef0bf3f34c7ecb810e832f"
+          "username": "252deadbeef0bf3f34c7ecb810e832f",
+          "excludephilips": false
         }   
     ]
 

--- a/index.js
+++ b/index.js
@@ -50,6 +50,11 @@ function PhilipsHuePlatform(log, config) {
   this.log = log;
   this.ip_address = config["ip_address"];
   this.username = config["username"];
+  this.excludephilips = config["excludephilips"];
+
+  if (typeof this.excludephilips === "undefined") {
+    this.excludephilips = false;
+  }
   
   this.log("PhilipsHue Platform Plugin Version " + this.getVersion());
   
@@ -135,6 +140,11 @@ PhilipsHuePlatform.prototype = {
         for (var deviceId in response.lights) {
           var device = response.lights[deviceId];
           device.id = deviceId;
+
+          if (that.excludephilips && device.manufacturername == "Philips") {
+            continue;
+          }
+
           var accessory = new PhilipsHueAccessory(that.log, device, api);
           foundAccessories.push(accessory);
         }


### PR DESCRIPTION
For people that have a Hue Bridge 2.0 and only want 3rd party bulb support for HomeKit.

Fixes #5 